### PR TITLE
Stop the Debug Log harassment for linux users

### DIFF
--- a/com.tsk.ide.vscode/Editor/ProjectGeneration/ProjectGeneration.cs
+++ b/com.tsk.ide.vscode/Editor/ProjectGeneration/ProjectGeneration.cs
@@ -1096,9 +1096,9 @@ namespace VSCodeEditor
                             return command;
                         }
                     }
-                    catch (System.ComponentModel.Win32Exception)
+                    catch (Exception)
                     {
-                        Debug.Log($"Command '{command}' not found or not accessible.");
+                        continue;
                     }
                     finally
                     {
@@ -1107,6 +1107,7 @@ namespace VSCodeEditor
                 }
             }
 
+            Debug.Log($"Could not find a compatible dotnet command.");
             return null; // No compatible command found
         }
     }


### PR DESCRIPTION
This pull request addresses an issue related to debug logging in the codebase that specifically affects Linux users. The existing code snippet includes a catch block that throws a System.ComponentModel.Win32Exception when a command is not found or not accessible.

The updated code has modified the catch block to catch a general Exception instead. This change allows the code to continue executing in case of any exception, ensuring that Linux users are not bombarded with unnecessary debug log messages. A new debug log message has also been added to notify when a compatible dotnet command cannot be found.

These modifications enhance the code's compatibility with Linux systems and improve the user experience by reducing unnecessary debug log output.