### PR TITLE
Fix possbile deadlock caused by not reading stdout.

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,19 +47,18 @@ Furthermore, the package introduces a dedicated configuration section within Ext
 
 ### Windows Only
 
-- Logout or restart Windows to allow changes to `%PATH%` to take effect.
-- The C# extension no longer ships with Microsoft Build Tools, so they must be installed manually.
-    - Download the [Build Tools for Visual Studio 2022](https://visualstudio.microsoft.com/downloads/#build-tools-for-visual-studio-2022).
-    - Install the .NET desktop build tools workload. No other components are required.
+-   Logout or restart Windows to allow changes to `%PATH%` to take effect.
+-   The C# extension no longer ships with Microsoft Build Tools, so they must be installed manually.
+    -   Download the [Build Tools for Visual Studio 2022](https://visualstudio.microsoft.com/downloads/#build-tools-for-visual-studio-2022).
+    -   Install the .NET desktop build tools workload. No other components are required.
 
 ### MacOS Only
 
-- To avoid seeing "Some projects have trouble loading. Please review the output for more details", make sure to install the latest stable [Mono](https://www.mono-project.com/download/) release.
-- If you aren't using C# Devkit, do the following:
+-   To avoid seeing "Some projects have trouble loading. Please review the output for more details", make sure to install the latest stable [Mono](https://www.mono-project.com/download/) release.
+-   If you aren't using C# Devkit, do the following:
     1. In your Visual Studio Code (VS Code) user settings, ensure that the configuration `"omnisharp.useModernNet":` is set to `false`. This configuration must be in place to prevent VS Code from utilizing the Mono version included in the official C# extension (specifically, version 6.0.X as of the latest release).
     2. Upon installing the latest version of Mono directly, set the following configuration value:
-    `"omnisharp.monoPath": "/Library/Frameworks/Mono.framework/Versions/Current"`
-        - Ensure you replace the provided path with the location where you installed Mono. By doing so, VS Code will strictly utilize the newly installed version of Mono for all operations.
+       `"omnisharp.monoPath": "/Library/Frameworks/Mono.framework/Versions/Current"` - Ensure you replace the provided path with the location where you installed Mono. By doing so, VS Code will strictly utilize the newly installed version of Mono for all operations.
 
 ## Install via Package Manager
 
@@ -89,7 +88,7 @@ Please follow the instrustions:
 -   Click +
 -   Select Add package by name... or Add package from git URL...
 -   Paste com.tsk.ide.vscode into name
--   Paste 1.4.2 into version
+-   Paste 1.4.3 into version
 -   Click Add
 
 Alternatively, merge the snippet to Packages/manifest.json
@@ -104,7 +103,7 @@ Alternatively, merge the snippet to Packages/manifest.json
         }
     ],
     "dependencies": {
-        "com.tsk.ide.vscode": "1.4.2"
+        "com.tsk.ide.vscode": "1.4.3"
     }
 }
 ```
@@ -130,9 +129,9 @@ Example .gitignore lines:
 /CSharpProjFolders/*
 ```
 
-### Extras 
+### Extras
 
-- To enable grammar and highlighting for jslib files, install the [jslib-for-unity](https://github.com/TheSleepyKoala/jslib-for-unity) package.
+-   To enable grammar and highlighting for jslib files, install the [jslib-for-unity](https://github.com/TheSleepyKoala/jslib-for-unity) package.
 
 ## Contributing
 

--- a/com.tsk.ide.vscode/CHANGELOG.md
+++ b/com.tsk.ide.vscode/CHANGELOG.md
@@ -1,90 +1,94 @@
 # Code Editor Package for Visual Studio Code
 
+## [1.4.3] - 2023-07-29
+
+-   Fix possible deadlock caused by not reading stdout
+
 ## [1.4.2] - 2023-06-13
 
-- Restrict Shell Compatibility for Project Generation's Dotnet Build (Mac/Linux)
+-   Restrict Shell Compatibility for Project Generation's Dotnet Build (Mac/Linux)
 
 ## [1.4.1] - 2023-06-05
 
-- Added .jslib to default extensions for VSCode.
-- Refactored configuration defaults and removed redundant options from omnisharp.json. - Thanks @ershn
-- Added support for renaming methods and classes using Omnisharp.
-- Updated settings.json to correctly utilize useModernNet, sdkIncludePrereleases, and organizeImportsOnFormat.
+-   Added .jslib to default extensions for VSCode.
+-   Refactored configuration defaults and removed redundant options from omnisharp.json. - Thanks @ershn
+-   Added support for renaming methods and classes using Omnisharp.
+-   Updated settings.json to correctly utilize useModernNet, sdkIncludePrereleases, and organizeImportsOnFormat.
 
 ## [1.4.0] - 2023-06-04
 
-- Refactored code to improve platform compatibility
+-   Refactored code to improve platform compatibility
 
 ## [1.3.9] - 2023-05-18
 
-- .csproj files are separated into their own folders within a main folder called "CSProjFolders" - Thanks @frarees
-- The ProjectReference element now includes a direct path to the file.
-  - Project element added
-  - Name element added
-- Compile element now includes a direct path to the file.
-- GenerateAssemblyInfo property set to false
-- Start of `dotnet build` support
+-   .csproj files are separated into their own folders within a main folder called "CSProjFolders" - Thanks @frarees
+-   The ProjectReference element now includes a direct path to the file.
+    -   Project element added
+    -   Name element added
+-   Compile element now includes a direct path to the file.
+-   GenerateAssemblyInfo property set to false
+-   Start of `dotnet build` support
 
 ## [1.3.7] - 2023-05-16
 
-- Added the option to disable adding Analyzers to all packages
-  - This means that it will only be added to .csproj files originating from the Assets Folder.
+-   Added the option to disable adding Analyzers to all packages
+    -   This means that it will only be added to .csproj files originating from the Assets Folder.
 
 ## [1.3.6] - 2023-05-10
 
-- [Added config section to Externals Tools](https://github.com/Chizaruu/com.tsk.ide.vscode/commit/8da03f5885c268eaecdfd904e6a324be9bf9b82a)
-- [Added Foldouts to remove visual clutter](https://github.com/Chizaruu/com.tsk.ide.vscode/commit/ba73359980ad49f8eca6d485eda6f54e76a2bbff)
-- A "TSKDoNotDelete" text file is generated when the package is first added. This was done to counter the constant auto-generation that occurred when you would delete the config files.
-- [Added Configurable Config Settings](https://github.com/Chizaruu/com.tsk.ide.vscode/commit/d7a33951346235a91606e258cb206cc68e65e723)
+-   [Added config section to Externals Tools](https://github.com/Chizaruu/com.tsk.ide.vscode/commit/8da03f5885c268eaecdfd904e6a324be9bf9b82a)
+-   [Added Foldouts to remove visual clutter](https://github.com/Chizaruu/com.tsk.ide.vscode/commit/ba73359980ad49f8eca6d485eda6f54e76a2bbff)
+-   A "TSKDoNotDelete" text file is generated when the package is first added. This was done to counter the constant auto-generation that occurred when you would delete the config files.
+-   [Added Configurable Config Settings](https://github.com/Chizaruu/com.tsk.ide.vscode/commit/d7a33951346235a91606e258cb206cc68e65e723)
 
 ## [1.3.4] - 2023-04-07
 
-- Minimum Unity version is now 2021.3
-- Added support for 2021/2022 NetStandard Editor Assemblies Compatibility Level (Not really, it's just a workaround until users start using 2023)
-- Added toggle for preferred default arguments for opening VSCode (You can choose between user or workspace)
-- Restructured the repository to be more in line with Unity's architecture (See <https://github.com/Unity-Technologies/com.unity.cinemachine> for more info)
+-   Minimum Unity version is now 2021.3
+-   Added support for 2021/2022 NetStandard Editor Assemblies Compatibility Level (Not really, it's just a workaround until users start using 2023)
+-   Added toggle for preferred default arguments for opening VSCode (You can choose between user or workspace)
+-   Restructured the repository to be more in line with Unity's architecture (See <https://github.com/Unity-Technologies/com.unity.cinemachine> for more info)
 
 ## [1.3.2] - 2023-04-05
 
-- Removed koalafied Microsoft.Unity.Analyzers dll
-- Removed LocationPaths option from omnisharp.json
-- Added support for Nuget package Microsoft.Unity.Analyzers (See ProjectGeneration.cs for more info)
+-   Removed koalafied Microsoft.Unity.Analyzers dll
+-   Removed LocationPaths option from omnisharp.json
+-   Added support for Nuget package Microsoft.Unity.Analyzers (See ProjectGeneration.cs for more info)
 
 ## [1.3.1] - 2023-04-01
 
-- Moved .omnisharp, .editorconfig, and analyzer generation to ProjectGeneration.cs to be in line with the rest of the project
-- Simplified XElement creation in ProjectGeneration.cs to be more readable
+-   Moved .omnisharp, .editorconfig, and analyzer generation to ProjectGeneration.cs to be in line with the rest of the project
+-   Simplified XElement creation in ProjectGeneration.cs to be more readable
 
 ## [1.3.0] - 2023-04-01
 
-- Added complete SDK support, this allows you to use Omnisharp's useModernNet in your project (Special thanks to Andrew Spiering @wackoisgod)
-- Added more predefined variables for the omnisharp.json file
-- Going forward, 2021.3 and below will only be able to use .Net Framework API compatibility level
-- Added support for .Net 4.8 API compatibility level for 2022.1 and above
-- Fixed failure while loading the analyzer reference 'Unity.SourceGenerators'
+-   Added complete SDK support, this allows you to use Omnisharp's useModernNet in your project (Special thanks to Andrew Spiering @wackoisgod)
+-   Added more predefined variables for the omnisharp.json file
+-   Going forward, 2021.3 and below will only be able to use .Net Framework API compatibility level
+-   Added support for .Net 4.8 API compatibility level for 2022.1 and above
+-   Fixed failure while loading the analyzer reference 'Unity.SourceGenerators'
 
 ## [1.2.7] - 2023-03-19
 
-- Added Unity Roslyn analyzers support (See <https://code.visualstudio.com/docs/other/unity#_enabling-unity-warnings>)
-- Added Formatting support (See CreateOmniSharpConfig() in VSCodeScriptEditor.cs)
-- Removed Rider Package (Spits)
-- Updated Text-Framework to 1.3.3
-- Start of Community Support
+-   Added Unity Roslyn analyzers support (See <https://code.visualstudio.com/docs/other/unity#_enabling-unity-warnings>)
+-   Added Formatting support (See CreateOmniSharpConfig() in VSCodeScriptEditor.cs)
+-   Removed Rider Package (Spits)
+-   Updated Text-Framework to 1.3.3
+-   Start of Community Support
 
 ## [1.2.6] - 2023-03-10
 
-- Added workspace file generation
-- End of Unity Support
+-   Added workspace file generation
+-   End of Unity Support
 
 ## [1.2.5] - 2022-02-07
 
-- Introduce OnGeneratedCSProjectFiles, OnGeneratedCSProject and OnGeneratedSlnSolution callbacks.
-- Always use forward slash in source paths
-- Analyzers use absolute paths
-- Ruleset files for roslyn analyzers
-- Extra snap search paths on Ubuntu
-- Specific c# language version for specific unity versions
-- No longer hide .gitignore in VSCode file explorer
+-   Introduce OnGeneratedCSProjectFiles, OnGeneratedCSProject and OnGeneratedSlnSolution callbacks.
+-   Always use forward slash in source paths
+-   Analyzers use absolute paths
+-   Ruleset files for roslyn analyzers
+-   Extra snap search paths on Ubuntu
+-   Specific c# language version for specific unity versions
+-   No longer hide .gitignore in VSCode file explorer
 
 ## [1.2.3] - 2020-10-23
 

--- a/com.tsk.ide.vscode/Editor/ProjectGeneration/ProjectGeneration.cs
+++ b/com.tsk.ide.vscode/Editor/ProjectGeneration/ProjectGeneration.cs
@@ -1031,7 +1031,6 @@ namespace VSCodeEditor
             {
                 FileName = dotnetCommand,
                 Arguments = "-c \"dotnet build\"",
-                RedirectStandardOutput = true,
                 UseShellExecute = false,
                 CreateNoWindow = true
             };

--- a/com.tsk.ide.vscode/Editor/ProjectGeneration/ProjectGeneration.cs
+++ b/com.tsk.ide.vscode/Editor/ProjectGeneration/ProjectGeneration.cs
@@ -1026,11 +1026,21 @@ namespace VSCodeEditor
                 return;
             }
 
+            string dotnetArguments = GetDotnetArguments();
+
+            if (dotnetArguments == null)
+            {
+                Debug.Log(
+                    "Could not find a compatible dotnet arguments. Aborting Nuget Json generation."
+                );
+                return;
+            }
+
             using var process = new System.Diagnostics.Process();
             var processStartInfo = new System.Diagnostics.ProcessStartInfo
             {
                 FileName = dotnetCommand,
-                Arguments = "-c \"dotnet build\"",
+                Arguments = dotnetArguments,
                 UseShellExecute = false,
                 CreateNoWindow = true
             };
@@ -1048,6 +1058,19 @@ namespace VSCodeEditor
             return "/bin/bash";
 #elif UNITY_EDITOR_OSX
             return "/bin/zsh";
+#else
+            return null;
+#endif
+        }
+
+        string GetDotnetArguments()
+        {
+#if UNITY_EDITOR_WIN
+            return "build";
+#elif UNITY_EDITOR_LINUX || UNITY_EDITOR_OSX
+            return "-c \"dotnet build\"";
+#else
+            return null;
 #endif
         }
     }

--- a/com.tsk.ide.vscode/package.json
+++ b/com.tsk.ide.vscode/package.json
@@ -2,7 +2,7 @@
     "name": "com.tsk.ide.vscode",
     "displayName": "TSK VSCode Editor",
     "description": "Unofficial code editor integration for supporting Visual Studio Code as code editor for Unity. Adds support for generating csproj files for intellisense purposes, auto discovery of installations, etc.",
-    "version": "1.4.2",
+    "version": "1.4.3",
     "unity": "2021.3",
     "dependencies": {},
     "author": {


### PR DESCRIPTION
Redirecting and then not reading from stdout can cause a deadlock, when the stdout pipe buffer is too small.