### PR TITLE
Fix the asmdef name to not conflict with the offical package

### DIFF
--- a/com.tsk.ide.vscode/Editor/com.tsk.vscode.Editor.asmdef
+++ b/com.tsk.ide.vscode/Editor/com.tsk.vscode.Editor.asmdef
@@ -1,5 +1,5 @@
 {
-    "name": "Unity.VSCode.Editor",
+    "name": "com.tsk.vscode.Editor",
     "rootNamespace": "",
     "references": [],
     "includePlatforms": [


### PR DESCRIPTION
The file was renamed, but the included name was not changed